### PR TITLE
feat: add retro crt theme

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -18,7 +18,10 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.1.0",
+    "autoprefixer": "^10.4.21",
     "jsdom": "^26.1.0",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.13",
     "typescript": "^5.2.2",
     "vite": "^5.0.0",
     "vitest": "^0.34.0"

--- a/apps/client/postcss.config.cjs
+++ b/apps/client/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,3 +1,11 @@
+import CRTFrame from './components/CRTFrame';
+import ThemeToggle from './components/ThemeToggle';
+
 export default function App() {
-  return <h1>Užupis Cat — Retro Tribute</h1>;
+  return (
+    <CRTFrame>
+      <h1 className="crt-glow text-2xl">Užupis Cat — Retro Tribute</h1>
+      <ThemeToggle className="absolute top-4 right-4" />
+    </CRTFrame>
+  );
 }

--- a/apps/client/src/components/CRTFrame.tsx
+++ b/apps/client/src/components/CRTFrame.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react';
+
+export default function CRTFrame({ children }: PropsWithChildren) {
+  return <div className="crt-frame">{children}</div>;
+}

--- a/apps/client/src/components/RetroButton.tsx
+++ b/apps/client/src/components/RetroButton.tsx
@@ -1,0 +1,10 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export default function RetroButton({ className = '', ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...props}
+      className={`retro-btn ${className}`.trim()}
+    />
+  );
+}

--- a/apps/client/src/components/ThemeToggle.tsx
+++ b/apps/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import RetroButton from './RetroButton';
+import Toast from './Toast';
+
+const STORAGE_KEY = 'retro-theme';
+
+type Theme = 'day' | 'night';
+
+interface Props {
+  className?: string;
+}
+
+export default function ThemeToggle({ className = '' }: Props) {
+  const [theme, setTheme] = useState<Theme>('day');
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggle = () => {
+    const next = theme === 'day' ? 'night' : 'day';
+    setTheme(next);
+    setToast(`${next === 'day' ? 'Day' : 'Night'} mode`);
+  };
+
+  return (
+    <>
+      <RetroButton onClick={toggle} aria-label="Toggle theme" className={className}>
+        {theme === 'day' ? 'Night' : 'Day'}
+      </RetroButton>
+      {toast && <Toast message={toast} />}
+    </>
+  );
+}

--- a/apps/client/src/components/Toast.tsx
+++ b/apps/client/src/components/Toast.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+interface ToastProps {
+  message: string;
+  duration?: number;
+}
+
+export default function Toast({ message, duration = 3000 }: ToastProps) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    setVisible(true);
+    const timer = setTimeout(() => setVisible(false), duration);
+    return () => clearTimeout(timer);
+  }, [message, duration]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 border border-[var(--color-text)] bg-[var(--color-bg)] px-4 py-2 crt-glow"
+    >
+      {message}
+    </div>
+  );
+}

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -1,0 +1,76 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  @font-face {
+    font-family: 'Press Start 2P';
+    font-style: normal;
+    font-weight: 400;
+    src: url('https://fonts.gstatic.com/s/pressstart2p/v11/e3t4euS0C3gIaWE7K8vB_m4Y3sffwL68.ttf') format('truetype');
+    font-display: swap;
+  }
+  :root {
+    --color-bg: #001100;
+    --color-text: #33ff66;
+  }
+  [data-theme='night'] {
+    --color-bg: #000022;
+    --color-text: #66ccff;
+  }
+  body {
+    @apply font-pixel bg-[var(--color-bg)] text-[var(--color-text)] min-h-screen;
+  }
+}
+
+@layer components {
+  .crt-frame {
+    @apply relative flex min-h-screen items-center justify-center bg-[var(--color-bg)] text-[var(--color-text)];
+  }
+  .crt-frame::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0) 0,
+      rgba(0, 0, 0, 0) 1px,
+      rgba(0, 0, 0, 0.2) 2px
+    );
+    opacity: 0.2;
+  }
+  .crt-frame::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    box-shadow: inset 0 0 20px var(--color-text);
+    opacity: 0.15;
+  }
+
+  .retro-btn {
+    @apply font-pixel bg-[var(--color-text)] text-[var(--color-bg)] px-4 py-2 transition-all motion-reduce:transition-none;
+    box-shadow: 4px 4px 0 var(--color-bg);
+  }
+  .retro-btn:hover {
+    @apply motion-reduce:transform-none;
+    transform: translate(2px, 2px);
+    box-shadow: 2px 2px 0 var(--color-bg);
+  }
+  .retro-btn:active {
+    @apply motion-reduce:transform-none;
+    transform: translate(4px, 4px);
+    box-shadow: 0 0 0 var(--color-bg);
+  }
+  .retro-btn:focus-visible {
+    outline: 2px solid var(--color-text);
+    outline-offset: 2px;
+  }
+}
+
+@layer utilities {
+  .crt-glow {
+    text-shadow: 0 0 2px var(--color-text), 0 0 6px var(--color-text);
+  }
+}

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/apps/client/tailwind.config.ts
+++ b/apps/client/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    fontFamily: {
+      pixel: ['"Press Start 2P"', 'ui-monospace', 'monospace'],
+    },
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.1.0
         version: 4.7.0(vite@5.4.19(@types/node@20.19.11))
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.21(postcss@8.5.6)
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.1.13
       typescript:
         specifier: ^5.2.2
         version: 5.9.2
@@ -903,6 +912,13 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  autoprefixer@10.4.21:
+    resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1265,6 +1281,9 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  fraction.js@4.3.7:
+    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -1676,6 +1695,10 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  normalize-range@0.1.2:
+    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
+    engines: {node: '>=0.10.0'}
+
   nwsapi@2.2.21:
     resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
 
@@ -1789,6 +1812,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2037,6 +2063,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwindcss@4.1.13:
+    resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -3044,6 +3073,16 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  autoprefixer@10.4.21(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.25.3
+      caniuse-lite: 1.0.30001737
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -3606,6 +3645,8 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  fraction.js@4.3.7: {}
+
   fresh@0.5.2: {}
 
   fs.realpath@1.0.0: {}
@@ -4036,6 +4077,8 @@ snapshots:
 
   node-releases@2.0.19: {}
 
+  normalize-range@0.1.2: {}
+
   nwsapi@2.2.21: {}
 
   object-assign@4.1.1: {}
@@ -4148,6 +4191,8 @@ snapshots:
       pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -4475,6 +4520,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tailwindcss@4.1.13: {}
 
   text-table@0.2.0: {}
 


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS and pixel font base for client app
- implement CRTFrame, RetroButton, Toast, and ThemeToggle components with day/night themes
- wrap app in CRTFrame and add theme toggle with toasts

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc545a13b4832382bb03c0d0b0a0f5