### PR TITLE
feat: add visit counter API and client

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,11 +1,24 @@
+import { useEffect, useState } from 'react';
 import CRTFrame from './components/CRTFrame';
 import ThemeToggle from './components/ThemeToggle';
 
 export default function App() {
+  const [visitCount, setVisitCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchVisits = async () => {
+      const res = await fetch('/api/visits');
+      const data = (await res.json()) as { total: number };
+      setVisitCount(data.total);
+    };
+    void fetchVisits();
+  }, []);
+
   return (
     <CRTFrame>
       <h1 className="crt-glow text-2xl">Užupis Cat — Retro Tribute</h1>
       <ThemeToggle className="absolute top-4 right-4" />
+      {visitCount !== null && <p className="mt-4">Visitor #{visitCount}</p>}
     </CRTFrame>
   );
 }

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -1,7 +1,21 @@
+import type { AddressInfo } from 'node:net';
 import { describe, it, expect } from 'vitest';
+import app, { resetVisits } from './index';
 
-describe('server placeholder test', () => {
-  it('should pass', () => {
-    expect(true).toBe(true);
+describe('GET /api/visits', () => {
+  it('increments and returns visit count', async () => {
+    resetVisits();
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+
+    const res1 = await fetch(`http://localhost:${port}/api/visits`);
+    const json1 = (await res1.json()) as { total: number };
+    expect(json1).toEqual({ total: 1 });
+
+    const res2 = await fetch(`http://localhost:${port}/api/visits`);
+    const json2 = (await res2.json()) as { total: number };
+    expect(json2).toEqual({ total: 2 });
+
+    server.close();
   });
 });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,12 +1,32 @@
 import express from 'express';
 
-const app = express();
+export const app = express();
 const port = process.env.PORT ?? 3000;
+
+let visits = 0;
+
+app.use((_req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  next();
+});
+
+app.get('/api/visits', (_req, res) => {
+  visits += 1;
+  res.json({ total: visits });
+});
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
-});
+export function resetVisits(): void {
+  visits = 0;
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+export default app;


### PR DESCRIPTION
## Summary
- add /api/visits endpoint with in-memory counter and CORS headers
- show visitor number on the home page
- cover visit counter with vitest

## Testing
- `pnpm -F server test`
- `pnpm -F client test`
- `pnpm -F server build`
- `pnpm -F client build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bddd6cde6c83239a93f481ac753f22