### PR TITLE
Add constitution homage page and navigation

### DIFF
--- a/apps/client/src/components/Nav.tsx
+++ b/apps/client/src/components/Nav.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+
+export default function Nav() {
+  return (
+    <nav aria-label="Main navigation" className="absolute left-4 top-4">
+      <ul className="flex gap-2">
+        <li>
+          <Link to="/" className="retro-btn">
+            Home
+          </Link>
+        </li>
+        <li>
+          <Link to="/constitution" className="retro-btn">
+            Constitution
+          </Link>
+        </li>
+        <li>
+          <Link to="/pledges" className="retro-btn">
+            Pledges
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -69,6 +69,27 @@
     outline-offset: 2px;
   }
 
+  .printer-paper {
+    @apply relative mx-auto max-w-md bg-white p-8 text-black;
+    box-shadow: 0 0 0 1px #ddd;
+  }
+  .printer-paper::before,
+  .printer-paper::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 16px;
+    background: radial-gradient(circle at 8px 8px, var(--color-bg) 2px, transparent 3px)
+      0 0/16px 16px repeat-y;
+  }
+  .printer-paper::before {
+    left: -16px;
+  }
+  .printer-paper::after {
+    right: -16px;
+  }
+
   .pixel-cat {
     @apply text-[var(--color-text)];
   }

--- a/apps/client/src/pages/Constitution.tsx
+++ b/apps/client/src/pages/Constitution.tsx
@@ -1,11 +1,24 @@
+import { Link } from 'react-router-dom';
 import CRTFrame from '../components/CRTFrame';
 import ThemeToggle from '../components/ThemeToggle';
+import Nav from '../components/Nav';
 
 export default function Constitution() {
   return (
     <CRTFrame>
-      <h1 className="crt-glow text-2xl">Constitution - Coming soon</h1>
+      <Nav />
       <ThemeToggle className="absolute top-4 right-4" />
+      <main className="printer-paper">
+        <h1 className="crt-glow mb-4 text-xl">Gentle Ideals</h1>
+        <ul className="list-disc space-y-2 pl-6">
+          <li>Everyone may dream kindly.</li>
+          <li>A passer-by may pause and smile.</li>
+          <li>A cat may help in difficult moments.</li>
+        </ul>
+        <Link to="/" className="retro-btn mt-6 inline-block">
+          Back Home
+        </Link>
+      </main>
     </CRTFrame>
   );
 }

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import RetroButton from '../components/RetroButton';
 import ThemeToggle from '../components/ThemeToggle';
 import PixelCat from '../components/PixelCat';
 import Toast from '../components/Toast';
+import Nav from '../components/Nav';
 
 const KONAMI = [
   'ArrowUp',
@@ -87,6 +88,7 @@ export default function Home() {
 
   return (
     <CRTFrame>
+      <Nav />
       <h1 className="crt-glow text-2xl">Užupis Cat — Retro Tribute</h1>
       <ThemeToggle className="absolute top-4 right-4" />
       {visitCount !== null && <p className="mt-4">Visitor #{visitCount}</p>}

--- a/apps/client/src/pages/Pledges.tsx
+++ b/apps/client/src/pages/Pledges.tsx
@@ -1,9 +1,11 @@
 import CRTFrame from '../components/CRTFrame';
 import ThemeToggle from '../components/ThemeToggle';
+import Nav from '../components/Nav';
 
 export default function Pledges() {
   return (
     <CRTFrame>
+      <Nav />
       <h1 className="crt-glow text-2xl">Pledges - Coming soon</h1>
       <ThemeToggle className="absolute top-4 right-4" />
     </CRTFrame>


### PR DESCRIPTION
## Summary
- add semantic Constitution homage page styled like perforated printer paper
- include retro-styled navigation links across client app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68befa7dcfe0832391849aa51c29a937