### PR TITLE
feat: add guestbook pledge feature

### DIFF
--- a/apps/client/package-lock.json
+++ b/apps/client/package-lock.json
@@ -8,8 +8,10 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.13",
@@ -1588,6 +1590,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.87.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.87.1.tgz",
+      "integrity": "sha512-HOFHVvhOCprrWvtccSzc7+RNqpnLlZ5R6lTmngb8aq7b4rc2/jDT0w+vLdQ4lD9bNtQ+/A4GsFXy030Gk4ollA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.87.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.87.1.tgz",
+      "integrity": "sha512-YKauf8jfMowgAqcxj96AHs+Ux3m3bWT1oSVKamaRPXSnW2HqSznnTCEkAVqctF1e/W9R/mPcyzzINIgpOH94qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.87.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2167,6 +2195,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3717,6 +3754,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3882,6 +3957,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "@tanstack/react-query": "^5.29.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './index.css';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/apps/client/src/pages/Pledges.tsx
+++ b/apps/client/src/pages/Pledges.tsx
@@ -1,12 +1,109 @@
+import { useState, useRef, FormEvent } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import CRTFrame from '../components/CRTFrame';
 import ThemeToggle from '../components/ThemeToggle';
 import Nav from '../components/Nav';
+import Toast from '../components/Toast';
+
+interface Pledge {
+  name?: string;
+  message: string;
+  timestamp: number;
+}
+
+async function fetchPledges(): Promise<Pledge[]> {
+  const res = await fetch('http://localhost:3000/api/pledge');
+  if (!res.ok) throw new Error('Failed to load pledges');
+  return res.json();
+}
 
 export default function Pledges() {
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+  const [toast, setToast] = useState('');
+  const queryClient = useQueryClient();
+  const submitTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const { data: pledges } = useQuery({ queryKey: ['pledges'], queryFn: fetchPledges });
+
+  const mutation = useMutation({
+    mutationFn: async (payload: { name?: string; message: string }) => {
+      const res = await fetch('http://localhost:3000/api/pledge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('Failed to save pledge');
+      return (await res.json()) as Pledge;
+    },
+    onMutate: async (payload) => {
+      await queryClient.cancelQueries({ queryKey: ['pledges'] });
+      const previous = queryClient.getQueryData<Pledge[]>(['pledges']) ?? [];
+      const optimistic: Pledge = { ...payload, timestamp: Date.now() };
+      queryClient.setQueryData(['pledges'], [optimistic, ...previous]);
+      setMessage('');
+      return { previous };
+    },
+    onError: (_err, _payload, context) => {
+      if (context?.previous) queryClient.setQueryData(['pledges'], context.previous);
+      setToast('Something went wrong');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['pledges'] });
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = message.trim();
+    if (trimmed.length === 0 || trimmed.length > 300) {
+      setToast('Message must be between 1 and 300 characters');
+      return;
+    }
+    if (submitTimer.current) clearTimeout(submitTimer.current);
+    submitTimer.current = setTimeout(() => {
+      mutation.mutate({ name: name.trim() || undefined, message: trimmed });
+    }, 300);
+  }
+
   return (
     <CRTFrame>
       <Nav />
-      <h1 className="crt-glow text-2xl">Pledges - Coming soon</h1>
+      <div className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name (optional)"
+            className="border border-[var(--color-text)] bg-transparent p-2"
+          />
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Your message"
+            maxLength={300}
+            required
+            className="border border-[var(--color-text)] bg-transparent p-2"
+          />
+          <button type="submit" className="self-start border border-[var(--color-text)] px-4 py-2">
+            Submit
+          </button>
+        </form>
+
+        {pledges && pledges.length > 0 ? (
+          <ul className="flex flex-col gap-2">
+            {pledges.map((p) => (
+              <li key={p.timestamp} className="border border-[var(--color-text)] p-2">
+                {p.name && <strong className="block">{p.name}</strong>}
+                <span>{p.message}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No pledges yet. Be the first!</p>
+        )}
+      </div>
+      {toast && <Toast message={toast} />}
       <ThemeToggle className="absolute top-4 right-4" />
     </CRTFrame>
   );

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
-import { describe, it, expect } from 'vitest';
-import app, { resetVisits } from './index';
+import { describe, it, expect, vi } from 'vitest';
+import app, { resetVisits, resetPledges } from './index';
 
 describe('GET /api/visits', () => {
   it('increments and returns visit count', async () => {
@@ -15,6 +15,68 @@ describe('GET /api/visits', () => {
     const res2 = await fetch(`http://localhost:${port}/api/visits`);
     const json2 = (await res2.json()) as { total: number };
     expect(json2).toEqual({ total: 2 });
+
+    server.close();
+  });
+});
+
+describe('POST /api/pledge', () => {
+  it('stores and returns a pledge', async () => {
+    resetPledges();
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await fetch(`http://localhost:${port}/api/pledge`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Ada', message: 'Hello world' }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { name?: string; message: string; timestamp: number };
+    expect(json.name).toBe('Ada');
+    expect(json.message).toBe('Hello world');
+    expect(typeof json.timestamp).toBe('number');
+    server.close();
+  });
+
+  it('validates message length', async () => {
+    resetPledges();
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await fetch(`http://localhost:${port}/api/pledge`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: '' }),
+    });
+    expect(res.status).toBe(400);
+    server.close();
+  });
+});
+
+describe('GET /api/pledge', () => {
+  it('returns pledges newest first', async () => {
+    resetPledges();
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+
+    vi.setSystemTime(new Date('2020-01-01').getTime());
+    await fetch(`http://localhost:${port}/api/pledge`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'first' }),
+    });
+
+    vi.setSystemTime(new Date('2020-01-02').getTime());
+    await fetch(`http://localhost:${port}/api/pledge`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'second' }),
+    });
+
+    const res = await fetch(`http://localhost:${port}/api/pledge`);
+    const json = (await res.json()) as { message: string }[];
+    expect(json.map((p) => p.message)).toEqual(['second', 'first']);
 
     server.close();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/client:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.29.0
+        version: 5.87.1(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -787,6 +790,14 @@ packages:
 
   '@tailwindcss/postcss@4.1.13':
     resolution: {integrity: sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==}
+
+  '@tanstack/query-core@5.87.1':
+    resolution: {integrity: sha512-HOFHVvhOCprrWvtccSzc7+RNqpnLlZ5R6lTmngb8aq7b4rc2/jDT0w+vLdQ4lD9bNtQ+/A4GsFXy030Gk4ollA==}
+
+  '@tanstack/react-query@5.87.1':
+    resolution: {integrity: sha512-YKauf8jfMowgAqcxj96AHs+Ux3m3bWT1oSVKamaRPXSnW2HqSznnTCEkAVqctF1e/W9R/mPcyzzINIgpOH94qg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3307,6 +3318,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.13
       postcss: 8.5.6
       tailwindcss: 4.1.13
+
+  '@tanstack/query-core@5.87.1': {}
+
+  '@tanstack/react-query@5.87.1(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.87.1
+      react: 18.3.1
 
   '@types/babel__core@7.20.5':
     dependencies:


### PR DESCRIPTION
## Summary
- add pledge API with in-memory storage and validation
- wire up React Query and guestbook page with optimistic updates
- cover new routes with unit tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68befe0703988323a33eeda717939729