### PR TITLE
feat: add simple i18n with language toggle

### DIFF
--- a/apps/client/src/components/LanguageToggle.tsx
+++ b/apps/client/src/components/LanguageToggle.tsx
@@ -1,0 +1,16 @@
+import RetroButton from './RetroButton';
+import { useI18n } from '../i18n';
+
+interface Props {
+  className?: string;
+}
+
+export default function LanguageToggle({ className = '' }: Props) {
+  const { lang, setLang } = useI18n();
+  const toggle = () => setLang(lang === 'en' ? 'lt' : 'en');
+  return (
+    <RetroButton onClick={toggle} className={className} aria-label="Toggle language">
+      {lang === 'en' ? 'LT' : 'EN'}
+    </RetroButton>
+  );
+}

--- a/apps/client/src/components/Nav.tsx
+++ b/apps/client/src/components/Nav.tsx
@@ -1,22 +1,24 @@
 import { Link } from 'react-router-dom';
+import { useI18n } from '../i18n';
 
 export default function Nav() {
+  const { t } = useI18n();
   return (
     <nav aria-label="Main navigation" className="absolute left-4 top-4">
       <ul className="flex gap-2">
         <li>
           <Link to="/" className="retro-btn">
-            Home
+            {t('nav.home')}
           </Link>
         </li>
         <li>
           <Link to="/constitution" className="retro-btn">
-            Constitution
+            {t('nav.constitution')}
           </Link>
         </li>
         <li>
           <Link to="/pledges" className="retro-btn">
-            Pledges
+            {t('nav.pledges')}
           </Link>
         </li>
       </ul>

--- a/apps/client/src/i18n/en.json
+++ b/apps/client/src/i18n/en.json
@@ -1,0 +1,31 @@
+{
+  "nav": {
+    "home": "Home",
+    "constitution": "Constitution",
+    "pledges": "Pledges"
+  },
+  "home": {
+    "title": "Užupis Cat — Retro Tribute",
+    "button": "Scratch Ear",
+    "toast": "Fear scratched away. Go create something kind.",
+    "tooltip": "Scratch the ear!"
+  },
+  "constitution": {
+    "title": "Gentle Ideals",
+    "lines": [
+      "Everyone may dream kindly.",
+      "A passer-by may pause and smile.",
+      "A cat may help in difficult moments."
+    ],
+    "back": "Back Home"
+  },
+  "pledges": {
+    "title": "Pledges",
+    "name": "Name (optional)",
+    "message": "Your message",
+    "submit": "Submit",
+    "noPledges": "No pledges yet. Be the first!",
+    "toastError": "Something went wrong",
+    "toastValidation": "Message must be between 1 and 300 characters"
+  }
+}

--- a/apps/client/src/i18n/index.tsx
+++ b/apps/client/src/i18n/index.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import en from './en.json';
+import lt from './lt.json';
+
+type Locale = 'en' | 'lt';
+
+const dictionaries = { en, lt } as const;
+
+interface I18nContextType {
+  lang: Locale;
+  setLang: (l: Locale) => void;
+  t: (key: string) => any;
+}
+
+const I18nContext = createContext<I18nContextType>({
+  lang: 'en',
+  setLang: () => {},
+  t: (key: string) => key,
+});
+
+const STORAGE_KEY = 'language';
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Locale>(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Locale | null;
+    return stored ?? 'en';
+    });
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, lang);
+  }, [lang]);
+
+  const t = (key: string): any => {
+    return key.split('.').reduce<any>((obj, k) => (obj ? obj[k] : undefined), dictionaries[lang]) ?? key;
+  };
+
+  return (
+    <I18nContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/apps/client/src/i18n/lt.json
+++ b/apps/client/src/i18n/lt.json
@@ -1,0 +1,31 @@
+{
+  "nav": {
+    "home": "Pradžia",
+    "constitution": "Konstitucija",
+    "pledges": "Pasižadėjimai"
+  },
+  "home": {
+    "title": "Užupis Katinas — Retro Duoklė",
+    "button": "Kasyk ausį",
+    "toast": "Baimė nukasyta. Kurk kažką gero.",
+    "tooltip": "Sdraskyk ausį!"
+  },
+  "constitution": {
+    "title": "Švelnūs Idealai",
+    "lines": [
+      "Kiekvienas gali svajoti švelniai.",
+      "Praeivis gali sustoti ir nusišypsoti.",
+      "Katinas gali padėti sunkiomis akimirkomis."
+    ],
+    "back": "Atgal į pradžią"
+  },
+  "pledges": {
+    "title": "Pasižadėjimai",
+    "name": "Vardas (nebūtina)",
+    "message": "Tavo žinutė",
+    "submit": "Pateikti",
+    "noPledges": "Dar nėra pasižadėjimų. Būk pirmas!",
+    "toastError": "Kažkas negerai",
+    "toastValidation": "Žinutė turi būti nuo 1 iki 300 simbolių"
+  }
+}

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './index.css';
+import { I18nProvider } from './i18n';
 
 const queryClient = new QueryClient();
 
@@ -11,7 +12,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <I18nProvider>
+          <App />
+        </I18nProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/apps/client/src/pages/Constitution.tsx
+++ b/apps/client/src/pages/Constitution.tsx
@@ -2,21 +2,27 @@ import { Link } from 'react-router-dom';
 import CRTFrame from '../components/CRTFrame';
 import ThemeToggle from '../components/ThemeToggle';
 import Nav from '../components/Nav';
+import LanguageToggle from '../components/LanguageToggle';
+import { useI18n } from '../i18n';
 
 export default function Constitution() {
+  const { t } = useI18n();
   return (
     <CRTFrame>
       <Nav />
-      <ThemeToggle className="absolute top-4 right-4" />
+      <div className="absolute top-4 right-4 flex gap-2">
+        <LanguageToggle />
+        <ThemeToggle />
+      </div>
       <main className="printer-paper">
-        <h1 className="crt-glow mb-4 text-xl">Gentle Ideals</h1>
+        <h1 className="crt-glow mb-4 text-xl">{t('constitution.title')}</h1>
         <ul className="list-disc space-y-2 pl-6">
-          <li>Everyone may dream kindly.</li>
-          <li>A passer-by may pause and smile.</li>
-          <li>A cat may help in difficult moments.</li>
+          {(t('constitution.lines') as string[]).map((line) => (
+            <li key={line}>{line}</li>
+          ))}
         </ul>
         <Link to="/" className="retro-btn mt-6 inline-block">
-          Back Home
+          {t('constitution.back')}
         </Link>
       </main>
     </CRTFrame>

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -5,6 +5,8 @@ import ThemeToggle from '../components/ThemeToggle';
 import PixelCat from '../components/PixelCat';
 import Toast from '../components/Toast';
 import Nav from '../components/Nav';
+import LanguageToggle from '../components/LanguageToggle';
+import { useI18n } from '../i18n';
 
 const KONAMI = [
   'ArrowUp',
@@ -26,6 +28,7 @@ export default function Home() {
   const [tooltip, setTooltip] = useState<string | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
   const konamiIndex = useRef(0);
+  const { t } = useI18n();
 
   useEffect(() => {
     const fetchVisits = async () => {
@@ -57,10 +60,10 @@ export default function Home() {
       setScratchTrigger((c) => c + 1);
       chime();
       if (showToast) {
-        setToast('Fear scratched away. Go create something kind.');
+        setToast(t('home.toast'));
       }
     },
-    [chime],
+    [chime, t],
   );
 
   useEffect(() => {
@@ -68,7 +71,7 @@ export default function Home() {
       const key = e.key.toLowerCase();
       if (key === 's') {
         scratch(false);
-        setTooltip('Sdraskyk ausį!');
+        setTooltip(t('home.tooltip'));
         setTimeout(() => setTooltip(null), 2000);
         return;
       }
@@ -89,15 +92,18 @@ export default function Home() {
   return (
     <CRTFrame>
       <Nav />
-      <h1 className="crt-glow text-2xl">Užupis Cat — Retro Tribute</h1>
-      <ThemeToggle className="absolute top-4 right-4" />
+      <h1 className="crt-glow text-2xl">{t('home.title')}</h1>
+      <div className="absolute top-4 right-4 flex gap-2">
+        <LanguageToggle />
+        <ThemeToggle />
+      </div>
       {visitCount !== null && <p className="mt-4">Visitor #{visitCount}</p>}
       <div className="relative">
         <PixelCat scratchTrigger={scratchTrigger} />
         {tooltip && <div className="tooltip">{tooltip}</div>}
       </div>
       <RetroButton onClick={() => scratch()} className="mt-4">
-        Scratch Ear
+        {t('home.button')}
       </RetroButton>
       {toast && <Toast message={toast} />}
     </CRTFrame>

--- a/apps/client/src/pages/Pledges.tsx
+++ b/apps/client/src/pages/Pledges.tsx
@@ -4,6 +4,8 @@ import CRTFrame from '../components/CRTFrame';
 import ThemeToggle from '../components/ThemeToggle';
 import Nav from '../components/Nav';
 import Toast from '../components/Toast';
+import LanguageToggle from '../components/LanguageToggle';
+import { useI18n } from '../i18n';
 
 const API = import.meta.env.VITE_API_BASE ?? '';
 
@@ -25,6 +27,7 @@ export default function Pledges() {
   const [toast, setToast] = useState('');
   const queryClient = useQueryClient();
   const submitTimer = useRef<ReturnType<typeof setTimeout>>();
+  const { t } = useI18n();
 
   const { data: pledges } = useQuery({ queryKey: ['pledges'], queryFn: fetchPledges });
 
@@ -48,7 +51,7 @@ export default function Pledges() {
     },
     onError: (_err, _payload, context) => {
       if (context?.previous) queryClient.setQueryData(['pledges'], context.previous);
-      setToast('Something went wrong');
+      setToast(t('pledges.toastError'));
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['pledges'] });
@@ -59,7 +62,7 @@ export default function Pledges() {
     e.preventDefault();
     const trimmed = message.trim();
     if (trimmed.length === 0 || trimmed.length > 300) {
-      setToast('Message must be between 1 and 300 characters');
+      setToast(t('pledges.toastValidation'));
       return;
     }
     if (submitTimer.current) clearTimeout(submitTimer.current);
@@ -72,23 +75,24 @@ export default function Pledges() {
     <CRTFrame>
       <Nav />
       <div className="flex flex-col gap-4">
+        <h1 className="crt-glow text-xl">{t('pledges.title')}</h1>
         <form onSubmit={handleSubmit} className="flex flex-col gap-2">
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Name (optional)"
+            placeholder={t('pledges.name') as string}
             className="border border-[var(--color-text)] bg-transparent p-2"
           />
           <textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}
-            placeholder="Your message"
+            placeholder={t('pledges.message') as string}
             maxLength={300}
             required
             className="border border-[var(--color-text)] bg-transparent p-2"
           />
           <button type="submit" className="self-start border border-[var(--color-text)] px-4 py-2">
-            Submit
+            {t('pledges.submit')}
           </button>
         </form>
 
@@ -102,11 +106,14 @@ export default function Pledges() {
             ))}
           </ul>
         ) : (
-          <p>No pledges yet. Be the first!</p>
+          <p>{t('pledges.noPledges')}</p>
         )}
       </div>
       {toast && <Toast message={toast} />}
-      <ThemeToggle className="absolute top-4 right-4" />
+      <div className="absolute top-4 right-4 flex gap-2">
+        <LanguageToggle />
+        <ThemeToggle />
+      </div>
     </CRTFrame>
   );
 }


### PR DESCRIPTION
## Summary
- add JSON-based i18n system and provider
- implement language toggle stored in localStorage
- localize Home, Constitution, and Pledges pages

## Testing
- `npm test` *(fails: Error: Failed to load url express...)*
- `npm test -w apps/client`
- `npm run lint -w apps/client` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0497d79d883238d2c1ad97421b656