### PR TITLE
Improve accessibility and high-contrast theme

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,9 +1,18 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
 import Home from './pages/Home';
 import Constitution from './pages/Constitution';
 import Pledges from './pages/Pledges';
 
 export default function App() {
+  const location = useLocation();
+
+  useEffect(() => {
+    // Send focus to page heading when navigating for screen reader context
+    const heading = document.getElementById('main-heading');
+    heading?.focus();
+  }, [location.pathname]);
+
   return (
     <Routes>
       <Route path="/" element={<Home />} />

--- a/apps/client/src/components/PixelCat.tsx
+++ b/apps/client/src/components/PixelCat.tsx
@@ -10,6 +10,7 @@ export default function PixelCat({ scratchTrigger }: PixelCatProps) {
   useEffect(() => {
     const ear = earRef.current;
     if (!ear) return;
+    // Trigger ear shake; CSS respects prefers-reduced-motion
     ear.classList.add('shake');
     const handle = () => ear.classList.remove('shake');
     ear.addEventListener('animationend', handle, { once: true });

--- a/apps/client/src/components/Toast.tsx
+++ b/apps/client/src/components/Toast.tsx
@@ -20,7 +20,8 @@ export default function Toast({ message, duration = 3000 }: ToastProps) {
     <div
       role="status"
       aria-live="polite"
-      className="fixed bottom-4 right-4 border border-[var(--color-text)] bg-[var(--color-bg)] px-4 py-2 crt-glow"
+      // High-contrast tokens ensure readable text against elevated background
+      className="fixed bottom-4 right-4 border border-[var(--color-text)] bg-elevated text-high px-4 py-2 crt-glow"
     >
       {message}
     </div>

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -14,10 +14,16 @@
   :root {
     --color-bg: #001100;
     --color-text: #33ff66;
+    /* High-contrast theme tokens */
+    --color-bg-elevated: #002200;
+    --color-text-high: #ffffff;
   }
   [data-theme='night'] {
     --color-bg: #000022;
     --color-text: #66ccff;
+    /* Night variant of high-contrast tokens */
+    --color-bg-elevated: #000044;
+    --color-text-high: #ffffff;
   }
   body {
     @apply font-pixel bg-[var(--color-bg)] text-[var(--color-text)] min-h-screen;
@@ -112,6 +118,7 @@
     }
   }
 
+  /* Disable ear animation when user prefers reduced motion */
   @media (prefers-reduced-motion: reduce) {
     .pixel-cat .ear.shake {
       animation: none;
@@ -119,7 +126,8 @@
   }
 
   .tooltip {
-    @apply absolute -top-6 left-1/2 -translate-x-1/2 border border-[var(--color-text)] bg-[var(--color-bg)] px-2 py-1 text-xs;
+    /* High-contrast tooltip styling for readability */
+    @apply absolute -top-6 left-1/2 -translate-x-1/2 border border-[var(--color-text)] bg-elevated text-high px-2 py-1 text-xs;
   }
 }
 

--- a/apps/client/src/pages/Constitution.tsx
+++ b/apps/client/src/pages/Constitution.tsx
@@ -15,7 +15,10 @@ export default function Constitution() {
         <ThemeToggle />
       </div>
       <main className="printer-paper">
-        <h1 className="crt-glow mb-4 text-xl">{t('constitution.title')}</h1>
+        {/* Focus target for route changes */}
+        <h1 id="main-heading" tabIndex={-1} className="crt-glow mb-4 text-xl">
+          {t('constitution.title')}
+        </h1>
         <ul className="list-disc space-y-2 pl-6">
           {(t('constitution.lines') as string[]).map((line) => (
             <li key={line}>{line}</li>

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -92,19 +92,25 @@ export default function Home() {
   return (
     <CRTFrame>
       <Nav />
-      <h1 className="crt-glow text-2xl">{t('home.title')}</h1>
       <div className="absolute top-4 right-4 flex gap-2">
         <LanguageToggle />
         <ThemeToggle />
       </div>
-      {visitCount !== null && <p className="mt-4">Visitor #{visitCount}</p>}
-      <div className="relative">
-        <PixelCat scratchTrigger={scratchTrigger} />
-        {tooltip && <div className="tooltip">{tooltip}</div>}
-      </div>
-      <RetroButton onClick={() => scratch()} className="mt-4">
-        {t('home.button')}
-      </RetroButton>
+      {/* Main content area for the page */}
+      <main className="flex flex-col items-center">
+        {/* Heading is focus target when routes change */}
+        <h1 id="main-heading" tabIndex={-1} className="crt-glow text-2xl">
+          {t('home.title')}
+        </h1>
+        {visitCount !== null && <p className="mt-4">Visitor #{visitCount}</p>}
+        <div className="relative">
+          <PixelCat scratchTrigger={scratchTrigger} />
+          {tooltip && <div className="tooltip">{tooltip}</div>}
+        </div>
+        <RetroButton onClick={() => scratch()} className="mt-4">
+          {t('home.button')}
+        </RetroButton>
+      </main>
       {toast && <Toast message={toast} />}
     </CRTFrame>
   );

--- a/apps/client/src/pages/Pledges.tsx
+++ b/apps/client/src/pages/Pledges.tsx
@@ -74,21 +74,29 @@ export default function Pledges() {
   return (
     <CRTFrame>
       <Nav />
-      <div className="flex flex-col gap-4">
-        <h1 className="crt-glow text-xl">{t('pledges.title')}</h1>
+      {/* Main pledge content */}
+      <main className="flex flex-col gap-4">
+        {/* Heading is focus target when routes change */}
+        <h1 id="main-heading" tabIndex={-1} className="crt-glow text-xl">
+          {t('pledges.title')}
+        </h1>
         <form onSubmit={handleSubmit} className="flex flex-col gap-2">
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder={t('pledges.name') as string}
+            aria-label={t('pledges.name') as string}
+            // Placeholder-only inputs need explicit labels for screen readers
             className="border border-[var(--color-text)] bg-transparent p-2"
           />
           <textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             placeholder={t('pledges.message') as string}
+            aria-label={t('pledges.message') as string}
             maxLength={300}
             required
+            // Ensure textarea is labelled for assistive tech
             className="border border-[var(--color-text)] bg-transparent p-2"
           />
           <button type="submit" className="self-start border border-[var(--color-text)] px-4 py-2">
@@ -108,7 +116,7 @@ export default function Pledges() {
         ) : (
           <p>{t('pledges.noPledges')}</p>
         )}
-      </div>
+      </main>
       {toast && <Toast message={toast} />}
       <div className="absolute top-4 right-4 flex gap-2">
         <LanguageToggle />

--- a/apps/client/tailwind.config.ts
+++ b/apps/client/tailwind.config.ts
@@ -6,7 +6,13 @@ export default {
     fontFamily: {
       pixel: ['"Press Start 2P"', 'ui-monospace', 'monospace'],
     },
-    extend: {},
+    extend: {
+      // High-contrast theme tokens consumed via utility classes like text-high
+      colors: {
+        high: 'var(--color-text-high)',
+        elevated: 'var(--color-bg-elevated)',
+      },
+    },
   },
   plugins: [],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Add high-contrast color tokens and use them for tooltips and toast
- Manage focus on route changes and mark main headings
- Label pledge form fields and respect prefers-reduced-motion

## Testing
- `npm test` *(fails: Failed to load url express in apps/server/src/index.ts)*
- `npm test -w apps/client`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c04df91fc883238efaaea21001e309