### PR TITLE
Add Docker deployment setup and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,57 @@
 
 A playful monorepo scaffold for a retro-styled tribute site.
 
-## Development
+## Quick start
 
 ```bash
-pnpm install
-pnpm -w dev
+npm install
+npm run dev
 ```
 
-Other scripts:
+The command above starts both the Vite client (port 5173) and the Express API server (port 3000).
 
-- `pnpm -w build`
-- `pnpm -w test`
-- `pnpm -w lint`
-- `pnpm -w format`
+## Scripts
 
-## Testing
+- `npm run dev` – run client and server in development mode
+- `npm run build` – build both apps
+- `npm test` – run unit tests for client and server
+- `npm run lint` – lint both apps
+
+## Development vs Production
+
+Development uses the Vite dev server with a proxy to the API. For production, build the apps and run the compiled server:
 
 ```bash
-pnpm -w test
+npm run build
+node apps/server/dist/index.js
 ```
 
-This runs unit tests for both apps and a Playwright end-to-end spec. The Playwright
-configuration starts the development servers automatically.
+The server reads the `PORT` environment variable (default `3000`).
 
-To run the E2E tests against a production build instead:
+## Docker
 
-1. Build the apps with `pnpm -w build`.
-2. Serve the built client and start the compiled server.
-3. Run `playwright test`.
+To build and run production containers locally:
+
+```bash
+docker compose up --build
+```
+
+- Client: http://localhost:5173
+- Server: http://localhost:5174
+
+The client container proxies `/api` to the server container.
+
+## Production Notes
+
+- The server enables `Access-Control-Allow-Origin: *` by default. Set a tighter policy for real deployments.
+- Configure ports with the `PORT` env variable in each service.
+- The client can point to a remote API by setting `VITE_API_BASE` at build time.
+
+## Replace the Pixel Cat
+
+The SVG used for the pixel cat lives in `apps/client/src/components/PixelCat.tsx`. Replace the `<svg>` markup with your own art. Keep an accessible name via `aria-label` and maintain motion preferences.
+
+## Accessibility and i18n
+
+- UI elements provide labels and respect `prefers-reduced-motion`.
+- Language strings live in `apps/client/src/i18n`. Add new `{lang}.json` files and update `index.tsx` to support additional locales.

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine AS prod
+WORKDIR /app
+ENV NODE_ENV=production
+RUN npm install --no-save express http-proxy-middleware
+COPY --from=build /app/dist ./dist
+COPY server.mjs ./server.mjs
+EXPOSE 5173
+CMD ["node", "server.mjs"]

--- a/apps/client/server.mjs
+++ b/apps/client/server.mjs
@@ -1,0 +1,21 @@
+import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const port = process.env.PORT || 5173;
+const apiTarget = process.env.API_PROXY_TARGET || 'http://server:5174';
+
+app.use('/api', createProxyMiddleware({ target: apiTarget, changeOrigin: true }));
+app.use(express.static(path.join(__dirname, 'dist')));
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+});
+
+app.listen(port, () => {
+  console.log(`Client listening on port ${port}`);
+});

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine AS prod
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+EXPOSE 5174
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  server:
+    build: ./apps/server
+    ports:
+      - "5174:5174"
+    environment:
+      - PORT=5174
+  client:
+    build: ./apps/client
+    ports:
+      - "5173:5173"
+    depends_on:
+      - server
+    environment:
+      - PORT=5173
+      - API_PROXY_TARGET=http://server:5174


### PR DESCRIPTION
## Summary
- add client Dockerfile and runtime server with API proxy
- add server Dockerfile
- add docker-compose.yml to run client and server together
- document npm workflow, production notes, docker usage, and accessibility/i18n

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing code)*
- `docker-compose config`


------
https://chatgpt.com/codex/tasks/task_e_68c062a0fb8c8323b2dfa32b00b5a8de